### PR TITLE
MySQL implementado

### DIFF
--- a/Fase2/initializeMySQL.sql
+++ b/Fase2/initializeMySQL.sql
@@ -1,1 +1,3 @@
+--Usuario "root" (por defecto) con contraseña "1234"
+
 CREATE SCHEMA `asociation_db` ;

--- a/Fase2/initializeMySQL.sql
+++ b/Fase2/initializeMySQL.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA `asociation_db` ;

--- a/Fase2/v2/asociationPlatform/src/main/resources/application.properties
+++ b/Fase2/v2/asociationPlatform/src/main/resources/application.properties
@@ -6,12 +6,10 @@ server.ssl.key-password = secret
 spring.mustache.suffix=.html
 logging.level.org.sprintframework.web=DEBUG
 
-spring.h2.console.enabled=true
-spring.datasource.url=jdbc:h2:mem:testdb
-
-spring.jpa.database-platform= org.hibernate.dialect.H2Dialect
-spring.h2.console.path=/h2-console
-spring.jpa.properties.hibernate.format_sql=true
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/asociation_db
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.jpa.hibernate.ddl-auto=create-drop
 
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE


### PR DESCRIPTION
-Por ahora se requiere que cada uno cree un server propio para que funcione

-Se administra desde localhost con puerto 3306

-Por ahora se utiliza el usuario por defecto root con contraseña 1234

-La base de datos h2 ya no existe en sustitución por MySQL